### PR TITLE
Streamlines module dependencies

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -22,3 +22,14 @@ output "acl_id" {
   description = "The id of the network acl for the subnets"
   value       = var.provision ? ibm_is_network_acl.subnet_acl[0].id : data.ibm_is_subnet.vpc_subnet[0].network_acl
 }
+
+output "vpc_name" {
+  description = "The name of the VPC where the subnets were provisioned"
+  value       = var.vpc_name
+  depends_on = [null_resource.print_names]
+}
+
+output "vpc_id" {
+  description = "The id of the VPC where the subnets were provisioned"
+  value       = data.ibm_is_vpc.vpc.id
+}


### PR DESCRIPTION
- Adds vpc_name and vpc_id to the output so that downstreams only need to depend on this module

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>