### PR TITLE
trim acl rule names to max 63 chars to prevent failures

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -90,7 +90,7 @@ resource ibm_is_network_acl_rule acl_rule {
 
   network_acl = var.provision ? ibm_is_network_acl.subnet_acl[0].id : ""
 
-  name        = "${local.name_prefix}-${local.acl_rules[count.index]["name"]}"
+  name        = substr("${local.name_prefix}-${local.acl_rules[count.index]["name"]}", 0, 63)
   action      = local.acl_rules[count.index]["action"]
   direction   = local.acl_rules[count.index]["direction"]
   source      = local.acl_rules[count.index]["source"]

--- a/test/stages/stage1-vpc.tf
+++ b/test/stages/stage1-vpc.tf
@@ -3,7 +3,7 @@ module "vpc" {
 
   resource_group_name = module.resource_group.name
   region              = var.region
-  name_prefix         = "${{var.name_prefix}}-extra-long-prefix"
+  name_prefix         = "${var.name_prefix}-extra-long-prefix"
   address_prefix_count = var.address_prefix_count
   address_prefixes = jsondecode(var.address_prefixes)
 }

--- a/test/stages/stage1-vpc.tf
+++ b/test/stages/stage1-vpc.tf
@@ -3,7 +3,7 @@ module "vpc" {
 
   resource_group_name = module.resource_group.name
   region              = var.region
-  name_prefix         = "${var.name_prefix}-extra-long-prefix"
+  name_prefix         = var.name_prefix
   address_prefix_count = var.address_prefix_count
   address_prefixes = jsondecode(var.address_prefixes)
 }

--- a/test/stages/stage1-vpc.tf
+++ b/test/stages/stage1-vpc.tf
@@ -3,7 +3,7 @@ module "vpc" {
 
   resource_group_name = module.resource_group.name
   region              = var.region
-  name_prefix         = var.name_prefix
+  name_prefix         = "${{var.name_prefix}}-extra-long-prefix"
   address_prefix_count = var.address_prefix_count
   address_prefixes = jsondecode(var.address_prefixes)
 }

--- a/test/stages/stage2-subnets.tf
+++ b/test/stages/stage2-subnets.tf
@@ -10,7 +10,7 @@ module "subnets" {
   ipv4_cidr_blocks   = jsondecode(var.ipv4_cidr_blocks)
   ipv4_address_count = var.ipv4_address_count
   acl_rules          = [{
-    name="ingress-ssh"
+    name="ingress-ssh---this-is-a-really-long-name-to-test-for-proper-string-trimming"
     action="allow"
     direction="inbound"
     source="0.0.0.0/0"
@@ -22,7 +22,7 @@ module "subnets" {
       source_port_max=22
     }
   }, {
-    name="egress-ssh"
+    name="egress-ssh---this-is-a-really-long-name-to-test-for-proper-string-trimming"
     action="allow"
     direction="outbound"
     destination="0.0.0.0/0"

--- a/test/stages/stage2-subnets.tf
+++ b/test/stages/stage2-subnets.tf
@@ -1,7 +1,6 @@
 module "subnets" {
   source = "./module"
 
-  name_prefix        = "testing-prefix"
   resource_group_name = module.resource_group.name
   region             = var.region
   vpc_name           = module.vpc.name

--- a/test/stages/stage2-subnets.tf
+++ b/test/stages/stage2-subnets.tf
@@ -1,6 +1,7 @@
 module "subnets" {
   source = "./module"
 
+  name_prefix        = "testing-prefix"
   resource_group_name = module.resource_group.name
   region             = var.region
   vpc_name           = module.vpc.name


### PR DESCRIPTION
Signed-off-by: Andrew Trice <amtrice@us.ibm.com>

fixes https://github.com/cloud-native-toolkit/terraform-ibm-vpc-subnets/issues/64